### PR TITLE
fix: toast.promise() type signature

### DIFF
--- a/src/lib/core/toast.ts
+++ b/src/lib/core/toast.ts
@@ -2,6 +2,7 @@ import { dismiss, remove, upsert } from './store';
 import {
 	type Toast,
 	type Renderable,
+	type IntoRenderable,
 	type DefaultToastOptions,
 	type ToastOptions,
 	type ToastType,
@@ -52,8 +53,8 @@ toast.promise = <T>(
 	promise: Promise<T>,
 	msgs: {
 		loading: Renderable;
-		success: Renderable;
-		error: Renderable;
+		success: IntoRenderable<T>;
+		error: IntoRenderable<unknown>;
 	},
 	opts?: DefaultToastOptions
 ) => {

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -10,6 +10,7 @@ export type ToastPosition =
 	| 'bottom-right';
 
 export type Renderable = typeof SvelteComponent | string | null;
+export type IntoRenderable<T> = string | null | ((value: T) => Renderable);
 
 export interface IconTheme {
 	primary: string;


### PR DESCRIPTION
I believe this should fix the issue.

I don't believe `type ValueOrFunction`  can be used in this instance, in particular, `typeof SvelteComponent` cannot be used as a value directly for the reasons explained in the related issue.

Feel free to comment or make edits if you find a more elegant way to express the type.
There may also be a conflict with another part of the codebase that I'm not familiar with?

Closes #13