### PR TITLE
improvement to toast.promise

### DIFF
--- a/src/lib/core/toast.ts
+++ b/src/lib/core/toast.ts
@@ -58,26 +58,29 @@ toast.promise = <T>(
 	},
 	opts?: DefaultToastOptions
 ) => {
-	const id = toast.loading(msgs.loading, { ...opts, ...opts?.loading });
-
-	promise
-		.then((p) => {
-			toast.success(resolveValue(msgs.success, p), {
-				id,
-				...opts,
-				...opts?.success
-			});
-			return p;
-		})
-		.catch((e) => {
-			toast.error(resolveValue(msgs.error, e), {
-				id,
-				...opts,
-				...opts?.error
-			});
-		});
-
-	return promise;
+	//default to Infinity, so that the loading toast will stay until we have resolved the promise
+    const id = toast.loading(msgs.loading, { duration: Infinity, 
+        ...opts, 
+        ...opts?.loading 
+    });
+    promise
+        .then((p) => {
+		// remove the toast explicity, instead of reusing the id with success/error toast. With this we don't need to override the opts of toast.loading for toast.success/toast.error
+        toast.remove(id)
+        toast.success(msgs.success ?? p, {
+            ...opts,
+            ...opts?.success
+        });
+        return p;
+    })
+        .catch((e) => {
+        toast.remove(id)
+        toast.error(msgs.error ?? e, {
+            ...opts,
+            ...opts?.error
+        });
+    });
+    return promise;
 };
 
 export default toast;


### PR DESCRIPTION
This PR aims to solve the following issues for `toast.promise`

- support dynamic toast message based on promise's result, fallback to the static message provided initially

- handle edge case where `toast.loading` has been set with `{duration: Infinity}`, and `toast.success` and `toast.error` will not go away as well

The only thing that I am not sure is why is `resolveValue` function used there previously.