### PR TITLE
fix: toast.promise() type errors with ValueOrFunction

### DIFF
--- a/src/lib/core/toast.ts
+++ b/src/lib/core/toast.ts
@@ -2,10 +2,10 @@ import { dismiss, remove, upsert } from './store';
 import {
 	type Toast,
 	type Renderable,
-	type IntoRenderable,
 	type DefaultToastOptions,
 	type ToastOptions,
 	type ToastType,
+	type ValueOrFunction,
 	resolveValue
 } from './types';
 import { genId } from './utils';
@@ -53,8 +53,8 @@ toast.promise = <T>(
 	promise: Promise<T>,
 	msgs: {
 		loading: Renderable;
-		success: IntoRenderable<T>;
-		error: IntoRenderable<unknown>;
+		success: ValueOrFunction<Renderable, T>;
+		error: ValueOrFunction<Renderable, any>;
 	},
 	opts?: DefaultToastOptions
 ) => {

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -10,7 +10,6 @@ export type ToastPosition =
 	| 'bottom-right';
 
 export type Renderable = typeof SvelteComponent | string | null;
-export type IntoRenderable<T> = string | null | ((value: T) => Renderable);
 
 export interface IconTheme {
 	primary: string;


### PR DESCRIPTION
This should solve the #13 (no runtime errors or type errors) without introducing a new type. 