### PR TITLE
feat: RTL support

### DIFF
--- a/src/lib/components/ToastWrapper.svelte
+++ b/src/lib/components/ToastWrapper.svelte
@@ -19,7 +19,7 @@
 	$: factor = toast.position?.includes('top') ? 1 : -1;
 	$: justifyContent =
 		(toast.position?.includes('center') && 'center') ||
-		(toast.position?.includes('right') && 'flex-end') ||
+		((toast.position?.includes('right') || toast.position?.includes('end')) && 'flex-end') ||
 		null;
 </script>
 

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -1,13 +1,24 @@
 import type { SvelteComponent } from 'svelte';
 
 export type ToastType = 'success' | 'error' | 'loading' | 'blank' | 'custom';
+/** Specifies the toast's position on the screen
+ *
+ * Logical positions (`start`, `end`) are recommended over absolute positions
+ * (`left`, `right`), as they automatically adjust based on the text direction
+ * of the locale (LTR or RTL). Examples:
+ * - Use `top-start` instead of `top-left`.
+ * - Use `top-end` instead of `top-right`. */
 export type ToastPosition =
 	| 'top-left'
 	| 'top-center'
 	| 'top-right'
 	| 'bottom-left'
 	| 'bottom-center'
-	| 'bottom-right';
+	| 'bottom-right'
+	| 'top-start'
+	| 'top-end'
+	| 'bottom-start'
+	| 'bottom-end';
 
 export type Renderable = typeof SvelteComponent | string | null;
 


### PR DESCRIPTION
Fixes #28 

Instead of asking users to specify a relative direction (`right`, `left`), we can take a page out of [CSS logical properties](https://drafts.csswg.org/css-logical/#intro) and use `start` and `end` as opposed to `left` and `right`.

As an example, here is how tailwindcss handled this recently: https://github.com/tailwindlabs/tailwindcss/pull/10166
