### PR TITLE
Add component tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.cache
+test-results
+playwright-report

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
 		"svelte": "^3.57.0 || ^4.0.0"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.31.2",
+		"@playwright/experimental-ct-svelte": "^1.35.1",
+		"@playwright/test": "^1.35.1",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/kit": "^1.20.5",
 		"@sveltejs/package": "^2.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,23 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/experimental-ct-svelte';
 
-const config: PlaywrightTestConfig = {
-	webServer: {
-		command: 'npm run build && npm run preview',
-		port: 4173
+export default defineConfig({
+	testDir: './tests/components',
+	timeout: 10 * 1000,
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI ? [['github'], ['html']] : [['html', { open: 'never' }]],
+	use: {
+		trace: 'retain-on-failure',
+		video: 'retain-on-failure',
+		ctPort: 3100,
+		ctTemplateDir: './tests/components/boilerplate'
 	},
-	testDir: 'tests'
-};
-
-export default config;
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] }
+		}
+	]
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -10,9 +10,12 @@ dependencies:
     version: 3.1.0(svelte@4.0.0)
 
 devDependencies:
+  '@playwright/experimental-ct-svelte':
+    specifier: ^1.35.1
+    version: 1.35.1(svelte@4.0.0)(vite@4.2.0)
   '@playwright/test':
-    specifier: ^1.31.2
-    version: 1.31.2
+    specifier: ^1.35.1
+    version: 1.35.1
   '@sveltejs/adapter-auto':
     specifier: ^2.0.0
     version: 2.0.0(@sveltejs/kit@1.20.5)
@@ -396,13 +399,48 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@playwright/test@1.31.2:
-    resolution: {integrity: sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==}
-    engines: {node: '>=14'}
+  /@playwright/experimental-ct-core@1.35.1:
+    resolution: {integrity: sha512-NSoUf6JDLeZFy0HiENwA1GkIwZHvg5KrygnZknwWs7O8yksYLsmiuMb09sf2zsZmfYgVen401SNgf3KfekbweA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      '@playwright/test': 1.35.1
+      vite: 4.3.9
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - terser
+    dev: true
+
+  /@playwright/experimental-ct-svelte@1.35.1(svelte@4.0.0)(vite@4.2.0):
+    resolution: {integrity: sha512-7CV6pXyZMX9IQl0+J9+eNIv1hZj23z9hMA0GHZr7EubkbJvneIB2HsMKgEGxgW/KSGRqPMBNResfl2ShmHgHHQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      '@playwright/experimental-ct-core': 1.35.1
+      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.0.0)(vite@4.2.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - svelte
+      - terser
+      - vite
+    dev: true
+
+  /@playwright/test@1.35.1:
+    resolution: {integrity: sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==}
+    engines: {node: '>=16'}
     hasBin: true
     dependencies:
       '@types/node': 18.15.3
-      playwright-core: 1.31.2
+      playwright-core: 1.35.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -1896,9 +1934,9 @@ packages:
       pathe: 1.1.0
     dev: true
 
-  /playwright-core@1.31.2:
-    resolution: {integrity: sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==}
-    engines: {node: '>=14'}
+  /playwright-core@1.35.1:
+    resolution: {integrity: sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==}
+    engines: {node: '>=16'}
     hasBin: true
     dev: true
 
@@ -2114,6 +2152,14 @@ packages:
 
   /rollup@3.19.1:
     resolution: {integrity: sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /rollup@3.25.3:
+    resolution: {integrity: sha512-ZT279hx8gszBj9uy5FfhoG4bZx8c+0A1sbqtr7Q3KNWIizpTdDEPZbV2xcbvHsnFp4MavCQYZyzApJ+virB8Yw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -2618,6 +2664,38 @@ packages:
       postcss: 8.4.21
       resolve: 1.22.1
       rollup: 3.19.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite@4.3.9:
+    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.17.12
+      postcss: 8.4.24
+      rollup: 3.25.3
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/src/lib/components/ToastWrapper.svelte
+++ b/src/lib/components/ToastWrapper.svelte
@@ -19,7 +19,7 @@
 	$: factor = toast.position?.includes('top') ? 1 : -1;
 	$: justifyContent =
 		(toast.position?.includes('center') && 'center') ||
-		(toast.position?.includes('right') && 'flex-end') ||
+		((toast.position?.includes('right') || toast.position?.includes('end')) && 'flex-end') ||
 		null;
 </script>
 

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -1,13 +1,24 @@
 import type { SvelteComponent } from 'svelte';
 
 export type ToastType = 'success' | 'error' | 'loading' | 'blank' | 'custom';
+/** Specifies the toast's position on the screen
+ *
+ * Logical positions (`start`, `end`) are recommended over absolute positions
+ * (`left`, `right`), as they automatically adjust based on the text direction
+ * of the locale (LTR or RTL). Examples:
+ * - Use `top-start` instead of `top-left`.
+ * - Use `top-end` instead of `top-right`. */
 export type ToastPosition =
 	| 'top-left'
 	| 'top-center'
 	| 'top-right'
 	| 'bottom-left'
 	| 'bottom-center'
-	| 'bottom-right';
+	| 'bottom-right'
+	| 'top-start'
+	| 'top-end'
+	| 'bottom-start'
+	| 'bottom-end';
 
 export type Renderable = typeof SvelteComponent | string | null;
 

--- a/tests/components/boilerplate/App.svelte
+++ b/tests/components/boilerplate/App.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import Toaster from '../../../src/lib/components/Toaster.svelte';
+	import toast from '../../../src/lib/core/toast';
+	import type { ToastProps } from './types';
+
+	export let toastProps: ToastProps;
+
+	onMount(() => {
+		toast(toastProps[0], toastProps[1]);
+	});
+</script>
+
+<Toaster />

--- a/tests/components/boilerplate/index.html
+++ b/tests/components/boilerplate/index.html
@@ -1,0 +1,6 @@
+<html lang="en">
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./index.ts"></script>
+	</body>
+</html>

--- a/tests/components/boilerplate/index.ts
+++ b/tests/components/boilerplate/index.ts
@@ -1,0 +1,2 @@
+// Apply theme here, add anything your component needs at runtime here.
+// import '../src/common.css';

--- a/tests/components/boilerplate/mount-toast.ts
+++ b/tests/components/boilerplate/mount-toast.ts
@@ -1,0 +1,15 @@
+import App from './App.svelte';
+import type { Mount, ToastProps } from './types';
+
+/** Helper function to mount a toast component with a given set of props. */
+export const mountToast = async ({
+	mount,
+	toastProps
+}: {
+	mount: Mount;
+	/** A tuple of props to pass to the `toast()` function. */
+	toastProps: ToastProps;
+}) => {
+	const component = await mount(App, { props: { toastProps: toastProps } });
+	return component;
+};

--- a/tests/components/boilerplate/types.ts
+++ b/tests/components/boilerplate/types.ts
@@ -1,0 +1,5 @@
+import type toast from '$lib';
+import type { test } from '@playwright/experimental-ct-svelte';
+
+export type Mount = Parameters<Parameters<typeof test>[1]>['0']['mount'];
+export type ToastProps = Parameters<typeof toast>;

--- a/tests/components/direction.spec.ts
+++ b/tests/components/direction.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/experimental-ct-svelte';
+import { mountToast } from './boilerplate/mount-toast';
+
+test.use({ viewport: { width: 500, height: 500 } });
+
+test.describe('LTR', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.evaluate(() => {
+			document.documentElement.lang = 'en';
+			document.documentElement.dir = 'ltr';
+		});
+	});
+
+	test('top-start', async ({ mount }) => {
+		const component = await mountToast({
+			mount,
+			toastProps: ['Hello world!', { position: 'top-start' }]
+		});
+
+		const toast = component.getByRole('status');
+		// toast should be top left
+		const toastRect = await toast.boundingBox();
+		expect(toastRect?.x).toBeLessThan(150);
+	});
+
+	test('top-end', async ({ mount }) => {
+		const component = await mountToast({
+			mount,
+			toastProps: ['Hello world!', { position: 'top-end' }]
+		});
+
+		const toast = component.getByRole('status');
+		// toast should be top right
+		const toastRect = await toast.boundingBox();
+		expect(toastRect?.x).toBeGreaterThan(350);
+	});
+
+	test('bottom-start', async ({ mount }) => {
+		const component = await mountToast({
+			mount,
+			toastProps: ['Hello world!', { position: 'bottom-start' }]
+		});
+
+		const toast = component.getByRole('status');
+		// toast should be bottom left
+		const toastRect = await toast.boundingBox();
+		expect(toastRect?.x).toBeLessThan(150);
+	});
+
+	test('bottom-end', async ({ mount }) => {
+		const component = await mountToast({
+			mount,
+			toastProps: ['Hello world!', { position: 'bottom-end' }]
+		});
+
+		const toast = component.getByRole('status');
+		// toast should be bottom right
+		const toastRect = await toast.boundingBox();
+		expect(toastRect?.x).toBeGreaterThan(350);
+	});
+});
+
+test.describe('RTL', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.evaluate(() => {
+			document.documentElement.lang = 'ar';
+			document.documentElement.dir = 'rtl';
+		});
+	});
+
+	test('top-start', async ({ mount }) => {
+		const component = await mountToast({
+			mount,
+			toastProps: ['مرحبا', { position: 'top-start' }]
+		});
+
+		const toast = component.getByRole('status');
+		// toast should be top right
+		const toastRect = await toast.boundingBox();
+		expect(toastRect?.x).toBeGreaterThan(350);
+	});
+
+	test('top-end', async ({ mount }) => {
+		const component = await mountToast({
+			mount,
+			toastProps: ['مرحبا', { position: 'top-end' }]
+		});
+
+		const toast = component.getByRole('status');
+		// toast should be top left
+		const toastRect = await toast.boundingBox();
+		expect(toastRect?.x).toBeLessThan(150);
+	});
+
+	test('bottom-start', async ({ mount }) => {
+		const component = await mountToast({
+			mount,
+			toastProps: ['مرحبا', { position: 'bottom-start' }]
+		});
+
+		const toast = component.getByRole('status');
+		// toast should be bottom right
+		const toastRect = await toast.boundingBox();
+		expect(toastRect?.x).toBeGreaterThan(350);
+	});
+
+	test('bottom-end', async ({ mount }) => {
+		const component = await mountToast({
+			mount,
+			toastProps: ['مرحبا', { position: 'bottom-end' }]
+		});
+
+		const toast = component.getByRole('status');
+		// toast should be bottom left
+		const toastRect = await toast.boundingBox();
+		expect(toastRect?.x).toBeLessThan(150);
+	});
+});

--- a/tests/components/toast.spec.ts
+++ b/tests/components/toast.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/experimental-ct-svelte';
+import { mountToast } from './boilerplate/mount-toast';
+
+test.use({ viewport: { width: 500, height: 500 } });
+
+test('should render', async ({ mount }) => {
+	const component = await mountToast({ mount, toastProps: ['Hello world!'] });
+	await expect(component.getByText('Hello world!')).toBeVisible();
+});


### PR DESCRIPTION
> Depends on #39 

Since component testing has not been setup yet, I opted to introduce it in it's own PR.

Until #39 is merged, [this](https://github.com/thenbe/svelte-french-toast/compare/inline-direction...component-tests
) diff may be used for a more accurate representation of the changes introduced by this PR.