### PR TITLE
Add aARIA role

### DIFF
--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -30,6 +30,7 @@
 	style={containerStyle}
 	on:mouseenter={handlers.startPause}
 	on:mouseleave={handlers.endPause}
+        aria-roledescription="alert"
 	role="alert"
 >
 	{#each _toasts as toast (toast.id)}


### PR DESCRIPTION
fix #44 

Using this library in the latest version of sveltekit. it's throw the following error. 
<img width="824" alt="Screenshot 2023-07-05 at 8 11 19 AM" src="https://github.com/kbrgl/svelte-french-toast/assets/53856673/5f3f36c1-4c2c-487b-a1cc-e0994d389d42">

I added a fix for it. Hope it help

again thanks for making this library it sooo good. 
