### PR TITLE
Add "props" to the toast options.

### DIFF
--- a/src/lib/components/ToastMessage.svelte
+++ b/src/lib/components/ToastMessage.svelte
@@ -8,7 +8,7 @@
 	{#if typeof toast.message === 'string'}
 		{toast.message}
 	{:else}
-		<svelte:component this={toast.message} {toast} />
+		<svelte:component this={toast.message} {toast} {...toast.props} />
 	{/if}
 </div>
 

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -48,6 +48,8 @@ export interface Toast {
 	pauseDuration: number;
 	position?: ToastPosition;
 
+	props?: any;
+	
 	ariaProps: {
 		role: 'status' | 'alert';
 		'aria-live': 'assertive' | 'off' | 'polite';
@@ -67,7 +69,7 @@ export type DOMToast = Toast & { offset: number };
 export type ToastOptions = Partial<
 	Pick<
 		Toast,
-		'id' | 'icon' | 'duration' | 'ariaProps' | 'className' | 'style' | 'position' | 'iconTheme'
+		'id' | 'icon' | 'duration' | 'ariaProps' | 'className' | 'style' | 'position' | 'iconTheme' | 'props'
 	>
 >;
 


### PR DESCRIPTION
The use case here is the following:

There is a custom Toast Component that accepts some props:

```svelte
<script lang="ts">
  export let icon;
  export let span;
</script>

<div style="display: flex; align-items: center;">
  {@html icon}
  <span>{span}</span>
</div>
```

This is currently possible actually, it would look like this:

```svelte
<script lang="ts">
  export let toast = {}
</script>

<div style="display: flex; align-items: center;">
  {@html toast.icon}
  <span>{toast.span}</span>
</div>
```

Then when you call the toast:

```ts
toast(Toast, {
  duration: 5000,
  position: 'bottom-right',
  //@ts-ignore
  icon: '<svg>...</svg>',
  //@ts-ignore
  span: 'Hello, World'
});
```

The issue here is:

1. Types don't allow for it, and you would have to provide a generic `& Record<any>` or something like that to the `Toast` interface to get it to work.
2. You would obviously run into issues with keys that the `Toast` interface already has.

Solution: Add props to Toast options


```ts
toast(Toast, {
  duration: 5000,
  position: 'bottom-right',
  props: {
    icon: '<svg>...</svg>',
    span: 'Hello, World'
  }
});
```