### PR TITLE
Fix svelte 5 warnings about ambiguousness of <div ../>

### DIFF
--- a/src/lib/components/CheckmarkIcon.svelte
+++ b/src/lib/components/CheckmarkIcon.svelte
@@ -6,7 +6,7 @@
 	export let secondary: IconTheme['secondary'] = '#fff';
 </script>
 
-<div style:--primary={primary} style:--secondary={secondary} />
+<div style:--primary={primary} style:--secondary={secondary}></div>
 
 <style>
 	div {

--- a/src/lib/components/ErrorIcon.svelte
+++ b/src/lib/components/ErrorIcon.svelte
@@ -6,7 +6,7 @@
 	export let secondary: IconTheme['secondary'] = '#fff';
 </script>
 
-<div style:--primary={primary} style:--secondary={secondary} />
+<div style:--primary={primary} style:--secondary={secondary}></div>
 
 <style>
 	div {

--- a/src/lib/components/LoaderIcon.svelte
+++ b/src/lib/components/LoaderIcon.svelte
@@ -6,7 +6,7 @@
 	export let secondary: IconTheme['secondary'] = '#e0e0e0';
 </script>
 
-<div style:--primary={primary} style:--secondary={secondary} />
+<div style:--primary={primary} style:--secondary={secondary}></div>
 
 <style>
 	div {


### PR DESCRIPTION
These changes fixes the following warnings:

3:28:15 PM [vite-plugin-svelte] C:/.../node_modules/.pnpm/svelte-french-toast@1.2.0_svelte@5.0-next.152/node_modules/svelte-french-toast/dist/components/ErrorIcon.svelte:6:0 Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`