### PR TITLE
Handle dynamic change to toast height

### DIFF
--- a/src/lib/components/ToastWrapper.svelte
+++ b/src/lib/components/ToastWrapper.svelte
@@ -9,11 +9,14 @@
 	export let toast: DOMToast;
 	export let setHeight: (height: number) => void;
 
-	let wrapperEl: HTMLElement;
-	onMount(() => {
-		setHeight(wrapperEl.getBoundingClientRect().height);
-	});
+	let clientHeight: number;
 
+	function onHeightChange(clientHeight: number) {
+		if (clientHeight === undefined) return;
+		setHeight(clientHeight);
+	}
+
+	$: onHeightChange(clientHeight);
 	$: top = toast.position?.includes('top') ? 0 : null;
 	$: bottom = toast.position?.includes('bottom') ? 0 : null;
 	$: factor = toast.position?.includes('top') ? 1 : -1;
@@ -24,7 +27,7 @@
 </script>
 
 <div
-	bind:this={wrapperEl}
+	bind:clientHeight
 	class="wrapper"
 	class:active={toast.visible}
 	class:transition={!prefersReducedMotion()}

--- a/src/lib/core/store.ts
+++ b/src/lib/core/store.ts
@@ -34,8 +34,8 @@ const clearFromRemoveQueue = (toastId: string) => {
 	}
 };
 
-export function update(toast: Partial<Toast>) {
-	if (toast.id) {
+export function update(toast: Partial<Toast>, clearTimeout = true) {
+	if (clearTimeout && toast.id) {
 		clearFromRemoveQueue(toast.id);
 	}
 	toasts.update(($toasts) => $toasts.map((t) => (t.id === toast.id ? { ...t, ...toast } : t)));

--- a/src/lib/core/use-toaster.ts
+++ b/src/lib/core/use-toaster.ts
@@ -36,7 +36,7 @@ const handlers = {
 		_endPause(Date.now());
 	},
 	updateHeight: (toastId: string, height: number) => {
-		update({ id: toastId, height });
+		update({ id: toastId, height }, false);
 	},
 	calculateOffset
 };


### PR DESCRIPTION
Fixes #51

Change toast's height property when toast wrapper div's height changes.

Note that we cannot use below one liner:
```ts
$: clientHeight !== undefined && setHeight(clientHeight);
``` 
because `setHeight` is re-created whenever `toasts` is modified.

### In Action
https://github.com/user-attachments/assets/47280513-2d6a-43f7-80da-77cc93a24ccf

You can test it with following example code:
```ts
toast.promise(promise, {
  loading: 'Saving...',
  success: `Settings saved! And some additional text that is very long and takes up multiple lines`,
  error: `Could not save. An enormous wall of error message is to be placed here, making the toast taller`
});
```
