### PR TITLE
[Svelte 5] Add missing style/className opts

### DIFF
--- a/src/lib/core/toast.ts
+++ b/src/lib/core/toast.ts
@@ -36,6 +36,8 @@ const createToast = <T extends Record<string, unknown> = Record<string, unknown>
 	iconTheme: opts?.iconTheme,
 	position: opts?.position,
 	props: opts?.props,
+	className: opts?.className,
+	style: opts?.style,
 	id: opts?.id || genId()
 });
 


### PR DESCRIPTION
Fixes an issue where `className` and `style` opts were not provided during `createToast(...)` call

It seems that these options were expected in `ToastBar.svelte`, but were never being provided due to not existing on the toast prop. Let me know if this seems like a valid fix, or if there's another expected way of providing these.

Note: This didn't look directly related to the svelte-5 branch, but it seems like that was where the latest work was happening in.