### PR TITLE
fix: use custom _sft-* css class names #72

### DIFF
--- a/src/lib/components/ToastBar.svelte
+++ b/src/lib/components/ToastBar.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import ToastIcon from './ToastIcon.svelte';
+	import type { Component as ComponentType, Snippet } from 'svelte';
 	import type { Toast, ToastPosition } from '../core/types';
 	import { prefersReducedMotion } from '../core/utils';
-	import type { Snippet, Component as ComponentType } from 'svelte';
+	import ToastIcon from './ToastIcon.svelte';
 	import ToastMessage from './ToastMessage.svelte';
 
 	interface Props {
@@ -28,13 +28,15 @@
 		return top ? 1 : -1;
 	});
 	let animation: string | undefined = $derived.by(() => {
-		const [enter, exit] = prefersReducedMotion() ? ['fadeIn', 'fadeOut'] : ['enter', 'exit'];
+		const [enter, exit] = prefersReducedMotion()
+			? ['_sft-fadeIn', '_sft-fadeOut']
+			: ['_sft-enter', '_sft-exit'];
 		return toast.visible ? enter : exit;
 	});
 </script>
 
 <div
-	class="base {toast.height ? animation : 'transparent'} {toast.className || ''}"
+	class="_sft-base {toast.height ? animation : '_sft-transparent'} {toast.className || ''}"
 	style="{style}; {toast.style}"
 	style:--factor={factor}
 >
@@ -94,7 +96,7 @@
 		}
 	}
 
-	.base {
+	._sft-base {
 		display: flex;
 		align-items: center;
 		background: #fff;
@@ -110,23 +112,23 @@
 		border-radius: 8px;
 	}
 
-	.transparent {
+	._sft-transparent {
 		opacity: 0;
 	}
 
-	.enter {
+	._sft-enter {
 		animation: enterAnimation 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
 	}
 
-	.exit {
+	._sft-exit {
 		animation: exitAnimation 0.4s cubic-bezier(0.06, 0.71, 0.55, 1) forwards;
 	}
 
-	.fadeIn {
+	._sft-fadeIn {
 		animation: fadeInAnimation 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
 	}
 
-	.fadeOut {
+	._sft-fadeOut {
 		animation: fadeOutAnimation 0.4s cubic-bezier(0.06, 0.71, 0.55, 1) forwards;
 	}
 </style>

--- a/src/lib/components/ToastIcon.svelte
+++ b/src/lib/components/ToastIcon.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+	import type { Toast } from '../core/types';
 	import CheckmarkIcon from './CheckmarkIcon.svelte';
 	import ErrorIcon from './ErrorIcon.svelte';
 	import LoaderIcon from './LoaderIcon.svelte';
-	import type { Toast } from '../core/types';
 
 	interface Props {
 		toast: Toast;
@@ -13,15 +13,15 @@
 </script>
 
 {#if typeof icon === 'string'}
-	<div class="animated">{icon}</div>
+	<div class="_sft-animated">{icon}</div>
 {:else if typeof icon !== 'undefined'}
 	{@const IconComponent = icon}
 	<IconComponent />
 {:else if type !== 'blank'}
-	<div class="indicator">
+	<div class="_sft-indicator">
 		<LoaderIcon {...iconTheme} />
 		{#if type !== 'loading'}
-			<div class="status">
+			<div class="_sft-status">
 				{#if type === 'error'}
 					<ErrorIcon {...iconTheme} />
 				{:else}
@@ -33,7 +33,7 @@
 {/if}
 
 <style>
-	.indicator {
+	._sft-indicator {
 		position: relative;
 		display: flex;
 		justify-content: center;
@@ -42,11 +42,11 @@
 		min-height: 20px;
 	}
 
-	.status {
+	._sft-status {
 		position: absolute;
 	}
 
-	.animated {
+	._sft-animated {
 		position: relative;
 		transform: scale(0.6);
 		opacity: 0.4;

--- a/src/lib/components/ToastMessage.svelte
+++ b/src/lib/components/ToastMessage.svelte
@@ -8,7 +8,7 @@
 	let { toast }: Props = $props();
 </script>
 
-<div class="message" {...toast.ariaProps}>
+<div class="_sft-message" {...toast.ariaProps}>
 	{#if typeof toast.message === 'string'}
 		{toast.message}
 	{:else}
@@ -18,7 +18,7 @@
 </div>
 
 <style>
-	.message {
+	._sft-message {
 		display: flex;
 		justify-content: center;
 		margin: 4px 10px;

--- a/src/lib/components/ToastWrapper.svelte
+++ b/src/lib/components/ToastWrapper.svelte
@@ -33,9 +33,9 @@
 
 <div
 	bind:clientHeight
-	class="wrapper"
-	class:active={toast.visible}
-	class:transition={!prefersReducedMotion()}
+	class="_sft-wrapper"
+	class:_sft-active={toast.visible}
+	class:_sft-transition={!prefersReducedMotion()}
 	style:--factor={factor}
 	style:--offset={toast.offset}
 	style:top
@@ -50,7 +50,7 @@
 </div>
 
 <style>
-	.wrapper {
+	._sft-wrapper {
 		left: 0;
 		right: 0;
 		display: flex;
@@ -58,15 +58,15 @@
 		transform: translateY(calc(var(--offset, 16px) * var(--factor) * 1px));
 	}
 
-	.transition {
+	._sft-transition {
 		transition: all 230ms cubic-bezier(0.21, 1.02, 0.73, 1);
 	}
 
-	.active {
+	._sft-active {
 		z-index: 9999;
 	}
 
-	.active > :global(*) {
+	._sft-active > :global(*) {
 		pointer-events: auto;
 	}
 </style>

--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import useToaster from '../core/use-toaster';
 	import type { DOMToast, ToastOptions, ToastPosition } from '../core/types';
+	import useToaster from '../core/use-toaster';
 	import ToastWrapper from './ToastWrapper.svelte';
 
 	interface Props {
@@ -37,7 +37,7 @@
 </script>
 
 <div
-	class="toaster {containerClassName || ''}"
+	class="_sft-toaster {containerClassName || ''}"
 	style={containerStyle}
 	onmouseenter={handlers.startPause}
 	onmouseleave={handlers.endPause}
@@ -49,7 +49,7 @@
 </div>
 
 <style>
-	.toaster {
+	._sft-toaster {
 		--default-offset: 16px;
 
 		position: fixed;

--- a/src/www/Examples.svelte
+++ b/src/www/Examples.svelte
@@ -10,7 +10,7 @@
 		<label
 			for={example.title}
 			class="cursor-pointer p-2 bg-gray-100 hover:border-blue-500 rounded-xl transition-colors border-2 border-transparent"
-			class:checked={example.title === selected}
+			class:_sft-checked={example.title === selected}
 		>
 			<input
 				type="radio"
@@ -42,7 +42,7 @@
 	input[type='radio'] {
 		@apply appearance-none;
 	}
-	.checked {
+	._sft-checked {
 		@apply border-blue-500 font-bold;
 	}
 </style>


### PR DESCRIPTION
This fixes #72.

I added a prefix for all css class names to avoid conflics with other css libraries.

I chose `_sft`. (Initials for **S**velte **F**rench-**T**oast)

Examples:
* Old: `wrapper`, new: `_sft-wrapper`.
* Old: `status`, new: `_sft-status`.