### PR TITLE
Add support passing Svelte 5 components to toast

### DIFF
--- a/src/lib/core/store.ts
+++ b/src/lib/core/store.ts
@@ -34,18 +34,24 @@ const clearFromRemoveQueue = (toastId: string) => {
 	}
 };
 
-export function update(toast: Partial<Toast>, clearTimeout = true) {
+export function update<T extends Record<string, unknown>>(
+	toast: Partial<Toast<T>>,
+	clearTimeout = true
+) {
 	if (clearTimeout && toast.id) {
 		clearFromRemoveQueue(toast.id);
 	}
-	toasts.update(($toasts) => $toasts.map((t) => (t.id === toast.id ? { ...t, ...toast } : t)));
+	const normalized = toast as Partial<Toast>;
+	toasts.update(($toasts) =>
+		$toasts.map((t) => (t.id === normalized.id ? { ...t, ...normalized } : t))
+	);
 }
 
-export function add(toast: Toast) {
-	toasts.update(($toasts) => [toast, ...$toasts].slice(0, TOAST_LIMIT));
+export function add<T extends Record<string, unknown>>(toast: Toast<T>) {
+	toasts.update(($toasts) => [toast as unknown as Toast, ...$toasts].slice(0, TOAST_LIMIT));
 }
 
-export function upsert(toast: Toast) {
+export function upsert<T extends Record<string, unknown>>(toast: Toast<T>) {
 	if (get(toasts).find((t) => t.id === toast.id)) {
 		update(toast);
 	} else {

--- a/src/lib/core/toast.ts
+++ b/src/lib/core/toast.ts
@@ -47,7 +47,8 @@ const createHandler =
 		return toast.id;
 	};
 
-const toast = <T extends Record<string, unknown> = Record<string, unknown>>(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const toast = <T extends Record<string, any> = Record<string, any>>(
 	message: Message<T>,
 	opts?: ToastOptions<T>
 ) => createHandler('blank')(message, opts);

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -1,4 +1,4 @@
-import type { SvelteComponent } from 'svelte';
+import type { Component, SvelteComponent } from 'svelte';
 
 export type ToastType = 'success' | 'error' | 'loading' | 'blank' | 'custom';
 /** Specifies the toast's position on the screen
@@ -22,6 +22,8 @@ export type ToastPosition =
 
 export type Renderable<T extends Record<string, unknown> = Record<string, unknown>> =
 	| typeof SvelteComponent<T>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	| Component<T, any, any>
 	| string
 	| null;
 


### PR DESCRIPTION
Was getting type errors when passing component to toast in a Svelte 5 project.